### PR TITLE
Fix NullReferenceException for SqlDataReader

### DIFF
--- a/Hotel_DataAccessLayer/clsBookingData.cs
+++ b/Hotel_DataAccessLayer/clsBookingData.cs
@@ -65,7 +65,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
             return IsFound;
@@ -125,7 +125,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
             return IsFound;
@@ -381,7 +381,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 
@@ -431,7 +431,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 

--- a/Hotel_DataAccessLayer/clsCountryData.cs
+++ b/Hotel_DataAccessLayer/clsCountryData.cs
@@ -51,7 +51,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 
@@ -98,7 +98,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 
@@ -136,7 +136,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 

--- a/Hotel_DataAccessLayer/clsGuestCompanionData.cs
+++ b/Hotel_DataAccessLayer/clsGuestCompanionData.cs
@@ -58,7 +58,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
             return IsFound;
@@ -296,7 +296,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 
@@ -335,7 +335,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 

--- a/Hotel_DataAccessLayer/clsGuestData.cs
+++ b/Hotel_DataAccessLayer/clsGuestData.cs
@@ -56,7 +56,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
             return IsFound;
@@ -107,7 +107,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
             return IsFound;
@@ -350,7 +350,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 
@@ -403,7 +403,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 

--- a/Hotel_DataAccessLayer/clsGuestOrderData.cs
+++ b/Hotel_DataAccessLayer/clsGuestOrderData.cs
@@ -63,7 +63,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
             return IsFound;
@@ -285,7 +285,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 
@@ -328,7 +328,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 

--- a/Hotel_DataAccessLayer/clsMenuItemData.cs
+++ b/Hotel_DataAccessLayer/clsMenuItemData.cs
@@ -66,7 +66,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
             return IsFound;
@@ -329,7 +329,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 

--- a/Hotel_DataAccessLayer/clsOrderItemData.cs
+++ b/Hotel_DataAccessLayer/clsOrderItemData.cs
@@ -57,7 +57,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
             return IsFound;
@@ -260,7 +260,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 
@@ -303,7 +303,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 

--- a/Hotel_DataAccessLayer/clsPaymentData.cs
+++ b/Hotel_DataAccessLayer/clsPaymentData.cs
@@ -57,7 +57,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
             return IsFound;
@@ -261,7 +261,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 
@@ -307,7 +307,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 

--- a/Hotel_DataAccessLayer/clsPersonData.cs
+++ b/Hotel_DataAccessLayer/clsPersonData.cs
@@ -71,7 +71,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 
@@ -136,7 +136,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 
@@ -400,7 +400,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 

--- a/Hotel_DataAccessLayer/clsReservationData.cs
+++ b/Hotel_DataAccessLayer/clsReservationData.cs
@@ -61,7 +61,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
             return IsFound;
@@ -282,7 +282,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 
@@ -333,7 +333,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 

--- a/Hotel_DataAccessLayer/clsRoomData.cs
+++ b/Hotel_DataAccessLayer/clsRoomData.cs
@@ -65,7 +65,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
             return IsFound;
@@ -125,7 +125,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
             return IsFound;
@@ -389,7 +389,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 
@@ -541,7 +541,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 

--- a/Hotel_DataAccessLayer/clsRoomServiceData.cs
+++ b/Hotel_DataAccessLayer/clsRoomServiceData.cs
@@ -55,7 +55,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
             return IsFound;
@@ -287,7 +287,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 

--- a/Hotel_DataAccessLayer/clsRoomTypeData.cs
+++ b/Hotel_DataAccessLayer/clsRoomTypeData.cs
@@ -61,7 +61,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
             return IsFound;
@@ -117,7 +117,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
             return IsFound;
@@ -364,7 +364,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 

--- a/Hotel_DataAccessLayer/clsUserData.cs
+++ b/Hotel_DataAccessLayer/clsUserData.cs
@@ -57,7 +57,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
             return IsFound;
@@ -111,7 +111,7 @@ namespace Hotel_DataAccessLayer
             }
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
             return IsFound;
@@ -384,7 +384,7 @@ namespace Hotel_DataAccessLayer
 
             finally
             {
-                reader.Close();
+                reader?.Close();
                 connection.Close();
             }
 


### PR DESCRIPTION
## Summary
- prevent null reference exceptions when `SqlDataReader` was never initialized

## Testing
- `dotnet build HotelManagementSystem/HotelManagementSystem.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ee2e5f788322aadce07a12fe415b