### PR TITLE
Fix stored user credentials index error

### DIFF
--- a/HotelManagementSystem/GlobalClasses/clsGlobal.cs
+++ b/HotelManagementSystem/GlobalClasses/clsGlobal.cs
@@ -61,8 +61,11 @@ namespace HotelManagementSystem.GlobalClasses
                         {
                             string[] UserCredentials = Line.Split(new string[] {"#//#"},StringSplitOptions.None);
 
-                            Username = UserCredentials[0];
-                            Password = UserCredentials[1];
+                            if (UserCredentials.Length >= 2)
+                            {
+                                Username = UserCredentials[0];
+                                Password = UserCredentials[1];
+                            }
                         }
 
                         return true;


### PR DESCRIPTION
## Summary
- check array length before indexing when reading stored credentials

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867efa7ed6083228b32a2a4fb67bf36