### PR TITLE
Fix index error in room service list

### DIFF
--- a/HotelManagementSystem/Rooms/RoomServices/frmListRoomServices.cs
+++ b/HotelManagementSystem/Rooms/RoomServices/frmListRoomServices.cs
@@ -21,10 +21,13 @@ namespace HotelManagementSystem.Rooms.RoomServices
 
         private void dgvRoomServicesList_DataBindingComplete(object sender, DataGridViewBindingCompleteEventArgs e)
         {
-            dgvRoomServicesList.Columns[0].Width = 200;
-            dgvRoomServicesList.Columns[1].Width = 200;
-            dgvRoomServicesList.Columns[2].Width = 200;
-            dgvRoomServicesList.Columns[3].Width = 650;
+            if (dgvRoomServicesList.ColumnCount >= 4)
+            {
+                dgvRoomServicesList.Columns[0].Width = 200;
+                dgvRoomServicesList.Columns[1].Width = 200;
+                dgvRoomServicesList.Columns[2].Width = 200;
+                dgvRoomServicesList.Columns[3].Width = 650;
+            }
 
         }
 


### PR DESCRIPTION
## Summary
- avoid `ArgumentOutOfRangeException` in the room service list by checking column count

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867f0e953148322b6ee4c460154118a