### PR TITLE
Fix dashboard chart initialization error

### DIFF
--- a/HotelManagementSystem/frmDashboard.cs
+++ b/HotelManagementSystem/frmDashboard.cs
@@ -42,6 +42,10 @@ namespace HotelManagementSystem
         {
             Series serie = chart1.Series["RoomsStatus"];
 
+            // Ensure that the series always contains three points
+            while (serie.Points.Count < 3)
+                serie.Points.Add(0);
+
             serie.Points[0].SetValueY(clsRoom.GetRoomsCountPerStatus(clsRoom.enAvailabilityStatus.Booked));
             serie.Points[1].SetValueY(clsRoom.GetRoomsCountPerStatus(clsRoom.enAvailabilityStatus.Available));
             serie.Points[2].SetValueY(clsRoom.GetRoomsCountPerStatus(clsRoom.enAvailabilityStatus.UnderMaintenance));


### PR DESCRIPTION
## Summary
- ensure RoomsStatus chart series always has three data points

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6868027f24608322bf7ffd4bfc165e0a