### PR TITLE
Fix edit option with empty selection

### DIFF
--- a/HotelManagementSystem/DiningMenuItems/frmListMenuItems.cs
+++ b/HotelManagementSystem/DiningMenuItems/frmListMenuItems.cs
@@ -158,7 +158,13 @@ namespace HotelManagementSystem.MenuItems
 
         private void editToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            int ItemID = (int)dgvMenuItemsList.CurrentRow.Cells[0].Value;
+            if (dgvMenuItemsList.CurrentRow == null || dgvMenuItemsList.CurrentRow.Index < 0)
+            {
+                MessageBox.Show("Please select a menu item to edit.", "Edit", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                return;
+            }
+
+            int ItemID = Convert.ToInt32(dgvMenuItemsList.CurrentRow.Cells[0].Value);
 
             Form frm = new frmAddUpdateMenuItem(ItemID);
             frm.Show();


### PR DESCRIPTION
## Summary
- check for selected row before launching the edit form

## Testing
- `dotnet build HotelManagementSystem/HotelManagementSystem.sln -v:m` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686803a6aaa88322a5ed8faddb9ad542