### PR TITLE
Improve page switching responsiveness

### DIFF
--- a/HotelManagementSystem/frmMain.cs
+++ b/HotelManagementSystem/frmMain.cs
@@ -28,6 +28,26 @@ namespace HotelManagementSystem
     public partial class frmMain : Form
     {
         private frmLogin _frmLogin;
+
+        private frmDashboard _frmDashboard;
+        private frmListReservations _frmReservations;
+        private frmListBookings _frmBookings;
+        private frmListRooms _frmRooms;
+        private frmListRoomTypes _frmRoomTypes;
+        private frmListRoomServices _frmRoomServices;
+        private frmListGuests _frmGuests;
+        private frmListUsers _frmUsers;
+        private frmListPayments _frmPayments;
+        private MenuItems.frmListMenuItems _frmMenuItems;
+        private frmListGuestOrders _frmGuestOrders;
+
+        private static T _EnsureForm<T>(ref T form) where T : Form, new()
+        {
+            if (form == null || form.IsDisposed)
+                form = new T();
+
+            return form;
+        }
         public frmMain(frmLogin LoginForm)
         {
             InitializeComponent();
@@ -50,60 +70,60 @@ namespace HotelManagementSystem
 
         private void btnDashboard_Click(object sender, EventArgs e)
         {
-            _FillFormInPanelContainer(new frmDashboard());
+            _FillFormInPanelContainer(_EnsureForm(ref _frmDashboard));
 
         }
 
         private void btnReservations_Click(object sender, EventArgs e)
         {
-            _FillFormInPanelContainer(new frmListReservations());
+            _FillFormInPanelContainer(_EnsureForm(ref _frmReservations));
         }
 
         private void btnBookings_Click(object sender, EventArgs e)
         {
-            _FillFormInPanelContainer(new frmListBookings());
+            _FillFormInPanelContainer(_EnsureForm(ref _frmBookings));
 
         }
 
         private void btnRooms_Click(object sender, EventArgs e)
         {
-            _FillFormInPanelContainer(new frmListRooms());
+            _FillFormInPanelContainer(_EnsureForm(ref _frmRooms));
         }
 
         private void btnRoomTypes_Click(object sender, EventArgs e)
         {
-            _FillFormInPanelContainer(new frmListRoomTypes());
+            _FillFormInPanelContainer(_EnsureForm(ref _frmRoomTypes));
         }
 
         private void btnRoomServices_Click(object sender, EventArgs e)
         {
-            _FillFormInPanelContainer(new frmListRoomServices());
+            _FillFormInPanelContainer(_EnsureForm(ref _frmRoomServices));
         }
 
         private void btnGuests_Click(object sender, EventArgs e)
         {
-            _FillFormInPanelContainer(new frmListGuests());
+            _FillFormInPanelContainer(_EnsureForm(ref _frmGuests));
         }
 
         private void btnUsers_Click(object sender, EventArgs e)
         {
-            _FillFormInPanelContainer(new frmListUsers());
+            _FillFormInPanelContainer(_EnsureForm(ref _frmUsers));
         }
 
         private void btnPayments_Click(object sender, EventArgs e)
         {
-            _FillFormInPanelContainer(new frmListPayments());
+            _FillFormInPanelContainer(_EnsureForm(ref _frmPayments));
         }
 
         private void btnDiningMenu_Click(object sender, EventArgs e)
         {
-            _FillFormInPanelContainer(new MenuItems.frmListMenuItems());
+            _FillFormInPanelContainer(_EnsureForm(ref _frmMenuItems));
 
         }
 
         private void btnGuestOrders_Click(object sender, EventArgs e)
         {
-           _FillFormInPanelContainer(new frmListGuestOrders());
+           _FillFormInPanelContainer(_EnsureForm(ref _frmGuestOrders));
         }
 
         private void btnLogout_Click(object sender, EventArgs e)
@@ -116,6 +136,17 @@ namespace HotelManagementSystem
         private async void frmMain_Load(object sender, EventArgs e)
         {
             _ = clsDataCache.PreloadAsync();
+            _EnsureForm(ref _frmDashboard);
+            _EnsureForm(ref _frmReservations);
+            _EnsureForm(ref _frmBookings);
+            _EnsureForm(ref _frmRooms);
+            _EnsureForm(ref _frmRoomTypes);
+            _EnsureForm(ref _frmRoomServices);
+            _EnsureForm(ref _frmGuests);
+            _EnsureForm(ref _frmUsers);
+            _EnsureForm(ref _frmPayments);
+            _EnsureForm(ref _frmMenuItems);
+            _EnsureForm(ref _frmGuestOrders);
             btnDashboard.PerformClick();
         }
     }


### PR DESCRIPTION
## Summary
- keep frequently used forms alive to avoid recreation delays
- initialize forms when the main form loads

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680bafcf208322915ae7fcebfb3523