### PR TITLE
Improve data loading responsiveness

### DIFF
--- a/HotelManagementSystem/DiningMenuItems/frmListMenuItems.cs
+++ b/HotelManagementSystem/DiningMenuItems/frmListMenuItems.cs
@@ -43,9 +43,9 @@ namespace HotelManagementSystem.MenuItems
 
         }
 
-        private void _RefreshMenuItemsList()
+        private async Task _RefreshMenuItemsList()
         {
-            _DataView = clsMenuItem.GetAllMenuItems().DefaultView;
+            _DataView = (await clsMenuItem.GetAllMenuItemsAsync()).DefaultView;
             dgvMenuItemsList.DataSource = _DataView;
           
             cbItemType.Visible = false;
@@ -73,9 +73,9 @@ namespace HotelManagementSystem.MenuItems
             _RefreshMenuItems();
         }
 
-        private void frmListMenuItems_Load(object sender, EventArgs e)
+        private async void frmListMenuItems_Load(object sender, EventArgs e)
         {
-            _RefreshMenuItemsList();
+            await _RefreshMenuItemsList();
         }
 
         private void dgvMenuItemsList_DataBindingComplete(object sender, DataGridViewBindingCompleteEventArgs e)
@@ -153,15 +153,15 @@ namespace HotelManagementSystem.MenuItems
 
         }
 
-        private void btnAddMenuItem_Click(object sender, EventArgs e)
+        private async void btnAddMenuItem_Click(object sender, EventArgs e)
         {
             Form frm = new frmAddUpdateMenuItem();
             frm.Show();
-            frmListMenuItems_Load(null, null);
+            await _RefreshMenuItemsList();
 
         }
 
-        private void editToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void editToolStripMenuItem_Click(object sender, EventArgs e)
         {
             if (dgvMenuItemsList.CurrentRow == null || dgvMenuItemsList.CurrentRow.Index < 0)
             {
@@ -173,7 +173,7 @@ namespace HotelManagementSystem.MenuItems
 
             Form frm = new frmAddUpdateMenuItem(ItemID);
             frm.Show();
-            frmListMenuItems_Load(null, null);
+            await _RefreshMenuItemsList();
 
         }
     }

--- a/HotelManagementSystem/Guests/frmListGuests.cs
+++ b/HotelManagementSystem/Guests/frmListGuests.cs
@@ -26,9 +26,9 @@ namespace HotelManagementSystem.Guests
             InitializeComponent();
         }
 
-        private void _RefreshGuestsList()
+        private async Task _RefreshGuestsList()
         {
-            _DataView = clsGuest.GetAllGuests().DefaultView;
+            _DataView = (await clsGuest.GetAllGuestsAsync()).DefaultView;
             dgvGuestsList.DataSource = _DataView;
 
             cbGender.Visible = false;
@@ -49,9 +49,9 @@ namespace HotelManagementSystem.Guests
                 _DataView.RowFilter = string.Format("[{0}] LIKE '%{1}%'", cbFilterByOptions.Text, txtFilterValue.Text.Trim());
         }
 
-        private void frmListGuests_Load(object sender, EventArgs e)
+        private async void frmListGuests_Load(object sender, EventArgs e)
         {
-            _RefreshGuestsList();
+            await _RefreshGuestsList();
         }
 
         private void dgvGuestsList_DataBindingComplete(object sender, DataGridViewBindingCompleteEventArgs e)
@@ -113,12 +113,12 @@ namespace HotelManagementSystem.Guests
             frm.ShowDialog();
         }
 
-        private void editToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void editToolStripMenuItem_Click(object sender, EventArgs e)
         {
             int PersonID = (int)dgvGuestsList.CurrentRow.Cells[1].Value;
             Form frm = new frmAddUpdatePerson(PersonID);
             frm.ShowDialog();
-            frmListGuests_Load(null, null);
+            await _RefreshGuestsList();
 
         }
 

--- a/HotelManagementSystem/Payments/frmListPayments.cs
+++ b/HotelManagementSystem/Payments/frmListPayments.cs
@@ -24,9 +24,9 @@ namespace HotelManagementSystem.Payments
             InitializeComponent();
         }
 
-        private void _RefreshPaymentsList()
+        private async Task _RefreshPaymentsList()
         {
-            _DataView = clsPayment.GetAllPayments().DefaultView;
+            _DataView = (await clsPayment.GetAllPaymentsAsync()).DefaultView;
             dgvPaymentsList.DataSource = _DataView;
 
             cbFilterByOptions.SelectedIndex = 0;
@@ -46,9 +46,9 @@ namespace HotelManagementSystem.Payments
                 _DataView.RowFilter = string.Format("[{0}] LIKE '%{1}%'", cbFilterByOptions.Text, txtFilterValue.Text.Trim());
         }
 
-        private void frmListPayments_Load(object sender, EventArgs e)
+        private async void frmListPayments_Load(object sender, EventArgs e)
         {
-            _RefreshPaymentsList();
+            await _RefreshPaymentsList();
         }
 
         private void dgvPaymentsList_DataBindingComplete(object sender, DataGridViewBindingCompleteEventArgs e)

--- a/HotelManagementSystem/Rooms/RoomServices/frmListRoomServices.cs
+++ b/HotelManagementSystem/Rooms/RoomServices/frmListRoomServices.cs
@@ -31,33 +31,33 @@ namespace HotelManagementSystem.Rooms.RoomServices
 
         }
 
-        private void _RefreshRoomTypesList()
+        private async Task _RefreshRoomTypesList()
         {
-            _DataView = clsRoomService.GetAllRoomServices().DefaultView;
+            _DataView = (await clsRoomService.GetAllRoomServicesAsync()).DefaultView;
             dgvRoomServicesList.DataSource = _DataView;
 
             cbFilterByOptions.SelectedIndex = 0;
         }
 
-        private void frmListRoomServices_Load(object sender, EventArgs e)
+        private async void frmListRoomServices_Load(object sender, EventArgs e)
         {
-            _RefreshRoomTypesList();       
+            await _RefreshRoomTypesList();
         }
 
-        private void editToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void editToolStripMenuItem_Click(object sender, EventArgs e)
         {
             int RoomServiceID = (int) dgvRoomServicesList.CurrentRow.Cells[0].Value;
 
             Form frm = new frmAddUpdateRoomService(RoomServiceID);
             frm.Show();
-            frmListRoomServices_Load(null, null);
+            await _RefreshRoomTypesList();
         }
 
-        private void btnAddRoomService_Click(object sender, EventArgs e)
+        private async void btnAddRoomService_Click(object sender, EventArgs e)
         {
             Form frm = new frmAddUpdateRoomService();
             frm.Show();
-            frmListRoomServices_Load(null, null);
+            await _RefreshRoomTypesList();
         }
 
         private void _FilterList()

--- a/HotelManagementSystem/Rooms/RoomTypes/frmListRoomTypes.cs
+++ b/HotelManagementSystem/Rooms/RoomTypes/frmListRoomTypes.cs
@@ -22,9 +22,9 @@ namespace HotelManagementSystem
             InitializeComponent();
         }
 
-        private void _RefreshRoomTypesList()
+        private async Task _RefreshRoomTypesList()
         {
-            _DataView = clsRoomType.GetAllRoomTypes().DefaultView;
+            _DataView = (await clsRoomType.GetAllRoomTypesAsync()).DefaultView;
             dgvRoomTypesList.DataSource = _DataView;
 
             cbFilterByOptions.SelectedIndex = 0;
@@ -79,9 +79,9 @@ namespace HotelManagementSystem
             }
         }
 
-        private void frmListRoomTypes_Load(object sender, EventArgs e)
+        private async void frmListRoomTypes_Load(object sender, EventArgs e)
         {
-            _RefreshRoomTypesList();
+            await _RefreshRoomTypesList();
         }
 
         private void dgvRoomTypesList_DataBindingComplete(object sender, DataGridViewBindingCompleteEventArgs e)
@@ -97,20 +97,20 @@ namespace HotelManagementSystem
             txtFilterValue.Focus();
         }
 
-        private void btnAddRoomType_Click(object sender, EventArgs e)
+        private async void btnAddRoomType_Click(object sender, EventArgs e)
         {
             Form frm = new frmAddUpdateRoomType();
             frm.ShowDialog();
-            frmListRoomTypes_Load(null, null);
+            await _RefreshRoomTypesList();
         }
 
-        private void editToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void editToolStripMenuItem_Click(object sender, EventArgs e)
         {
             int RoomTypeID = (int)dgvRoomTypesList.CurrentRow.Cells[0].Value;
 
             Form frm = new frmAddUpdateRoomType(RoomTypeID);
             frm.ShowDialog();
-            frmListRoomTypes_Load(null, null);
+            await _RefreshRoomTypesList();
         }
 
     }

--- a/HotelManagementSystem/Rooms/frmListRooms.cs
+++ b/HotelManagementSystem/Rooms/frmListRooms.cs
@@ -56,9 +56,9 @@ namespace HotelManagementSystem.Rooms
                 _FillComboBoxWithRoomStatus();
         }
 
-        private void _RefreshRoomsList()
+        private async Task _RefreshRoomsList()
         {
-            _DataView = clsRoom.GetAllRooms().DefaultView;
+            _DataView = (await clsRoom.GetAllRoomsAsync()).DefaultView;
             dgvRoomsList.DataSource = _DataView;
 
             comboBox.Visible = false;
@@ -77,9 +77,9 @@ namespace HotelManagementSystem.Rooms
 
         }
 
-        private void frmListRooms_Load(object sender, EventArgs e)
+        private async void frmListRooms_Load(object sender, EventArgs e)
         {
-            _RefreshRoomsList();
+            await _RefreshRoomsList();
         }
 
         private void dgvRoomsList_DataBindingComplete(object sender, DataGridViewBindingCompleteEventArgs e)
@@ -90,11 +90,11 @@ namespace HotelManagementSystem.Rooms
             }
         }
 
-        private void btnAddRoom_Click(object sender, EventArgs e)
+        private async void btnAddRoom_Click(object sender, EventArgs e)
         {
             Form frm = new frmAddUpdateRoom();
             frm.ShowDialog();
-            _RefreshRoomsList();
+            await _RefreshRoomsList();
         }
 
         private void cbFilterByOptions_SelectedIndexChanged(object sender, EventArgs e)
@@ -148,23 +148,23 @@ namespace HotelManagementSystem.Rooms
             frm.ShowDialog();
         }
 
-        private void AddRoomtoolStripMenuItem_Click(object sender, EventArgs e)
+        private async void AddRoomtoolStripMenuItem_Click(object sender, EventArgs e)
         {
             Form frm = new frmAddUpdateRoom();
             frm.ShowDialog();
-            frmListRooms_Load(null, null);
+            await _RefreshRoomsList();
 
         }
 
-        private void editToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void editToolStripMenuItem_Click(object sender, EventArgs e)
         {
             int RoomID = (int)dgvRoomsList.CurrentRow.Cells[0].Value;
             Form frm = new frmAddUpdateRoom(RoomID);
             frm.ShowDialog();
-            frmListRooms_Load(null, null);
+            await _RefreshRoomsList();
         }
 
-        private void deleteToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void deleteToolStripMenuItem_Click(object sender, EventArgs e)
         {
             int RoomID = (int)dgvRoomsList.CurrentRow.Cells[0].Value;
 
@@ -202,7 +202,7 @@ namespace HotelManagementSystem.Rooms
                 {
                     MessageBox.Show($"Room with RoomID = {RoomID} was put under maintenance successfully !", "Information",
                     MessageBoxButtons.OK, MessageBoxIcon.Information);
-                    frmListRooms_Load(null, null);
+                    await _RefreshRoomsList();
                 }
 
                 else

--- a/HotelManagementSystem/Users/frmListUsers.cs
+++ b/HotelManagementSystem/Users/frmListUsers.cs
@@ -20,9 +20,9 @@ namespace HotelManagementSystem.Users
             InitializeComponent();
         }
 
-        private void _RefreshUsersList()
+        private async Task _RefreshUsersList()
         {
-            _DataView = clsUser.GetAllUsers().DefaultView;
+            _DataView = (await clsUser.GetAllUsersAsync()).DefaultView;
             dgvUsersList.DataSource = _DataView;
 
             cbIsActive.Visible = false;
@@ -43,9 +43,9 @@ namespace HotelManagementSystem.Users
                 _DataView.RowFilter = string.Format("[{0}] LIKE '%{1}%'", cbFilterByOptions.Text, txtFilterValue.Text.Trim());
         }
 
-        private void frmListUsers_Load(object sender, EventArgs e)
+        private async void frmListUsers_Load(object sender, EventArgs e)
         {
-            _RefreshUsersList();
+            await _RefreshUsersList();
         }
 
         private void dgvUsersList_DataBindingComplete(object sender, DataGridViewBindingCompleteEventArgs e)
@@ -56,11 +56,11 @@ namespace HotelManagementSystem.Users
             }
         }
 
-        private void btnAddUser_Click(object sender, EventArgs e)
+        private async void btnAddUser_Click(object sender, EventArgs e)
         {
             Form frm = new frmAddUpdateUser();
             frm.ShowDialog();
-            _RefreshUsersList();
+            await _RefreshUsersList();
         }
 
         private void cbFilterByOptions_SelectedIndexChanged(object sender, EventArgs e)
@@ -124,18 +124,18 @@ namespace HotelManagementSystem.Users
             Form frm = new frmShowUserInfo(UserID);
         }
 
-        private void AddUsertoolStripMenuItem_Click(object sender, EventArgs e)
+        private async void AddUsertoolStripMenuItem_Click(object sender, EventArgs e)
         {
             Form frm = new frmAddUpdateUser();
             frm.ShowDialog();
-            _RefreshUsersList();
+            await _RefreshUsersList();
         }
 
-        private void editToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void editToolStripMenuItem_Click(object sender, EventArgs e)
         {
             int UserID = (int)dgvUsersList.CurrentRow.Cells[0].Value;
             Form frm = new frmAddUpdateUser(UserID);
-            _RefreshUsersList();
+            await _RefreshUsersList();
         }
 
         private void deleteToolStripMenuItem_Click(object sender, EventArgs e)

--- a/Hotel_BusinessLayer/clsDataCache.cs
+++ b/Hotel_BusinessLayer/clsDataCache.cs
@@ -7,11 +7,25 @@ namespace Hotel_BusinessLayer
     {
         public static DataTable Reservations { get; private set; }
         public static DataTable Bookings { get; private set; }
+        public static DataTable Rooms { get; private set; }
+        public static DataTable RoomTypes { get; private set; }
+        public static DataTable RoomServices { get; private set; }
+        public static DataTable Guests { get; private set; }
+        public static DataTable Users { get; private set; }
+        public static DataTable Payments { get; private set; }
+        public static DataTable MenuItems { get; private set; }
 
         public static async Task PreloadAsync()
         {
             Reservations = await clsReservation.GetAllReservationsAsync(true);
             Bookings = await clsBooking.GetAllBookingsAsync(true);
+            Rooms = await clsRoom.GetAllRoomsAsync(true);
+            RoomTypes = await clsRoomType.GetAllRoomTypesAsync(true);
+            RoomServices = await clsRoomService.GetAllRoomServicesAsync(true);
+            Guests = await clsGuest.GetAllGuestsAsync(true);
+            Users = await clsUser.GetAllUsersAsync(true);
+            Payments = await clsPayment.GetAllPaymentsAsync(true);
+            MenuItems = await clsMenuItem.GetAllMenuItemsAsync(true);
         }
     }
 }

--- a/Hotel_BusinessLayer/clsGuest.cs
+++ b/Hotel_BusinessLayer/clsGuest.cs
@@ -110,9 +110,22 @@ namespace Hotel_BusinessLayer
             return clsGuestData.DeleteGuest(GuestID);
         }
 
-        public static DataTable GetAllGuests()
+        private static DataTable _guestsCache;
+        private static readonly object _guestsLock = new object();
+
+        public static DataTable GetAllGuests(bool forceRefresh = false)
         {
-            return clsGuestData.GetAllGuests();
+            lock (_guestsLock)
+            {
+                if (_guestsCache == null || forceRefresh)
+                    _guestsCache = clsGuestData.GetAllGuests();
+                return _guestsCache.Copy();
+            }
+        }
+
+        public static Task<DataTable> GetAllGuestsAsync(bool forceRefresh = false)
+        {
+            return Task.Run(() => GetAllGuests(forceRefresh));
         }
 
         public static DataTable GetAllGuestCompanions(int GuestID , int BookingID)

--- a/Hotel_BusinessLayer/clsMenuItem.cs
+++ b/Hotel_BusinessLayer/clsMenuItem.cs
@@ -103,9 +103,22 @@ namespace Hotel_BusinessLayer
             return clsMenuItemData.DeleteMenuItem(ItemID);
         }
 
-        public static DataTable GetAllMenuItems()
+        private static DataTable _menuItemsCache;
+        private static readonly object _menuItemsLock = new object();
+
+        public static DataTable GetAllMenuItems(bool forceRefresh = false)
         {
-            return clsMenuItemData.GetAllMenuItems();
+            lock (_menuItemsLock)
+            {
+                if (_menuItemsCache == null || forceRefresh)
+                    _menuItemsCache = clsMenuItemData.GetAllMenuItems();
+                return _menuItemsCache.Copy();
+            }
+        }
+
+        public static Task<DataTable> GetAllMenuItemsAsync(bool forceRefresh = false)
+        {
+            return Task.Run(() => GetAllMenuItems(forceRefresh));
         }
     }
 }

--- a/Hotel_BusinessLayer/clsPayment.cs
+++ b/Hotel_BusinessLayer/clsPayment.cs
@@ -95,9 +95,22 @@ namespace Hotel_BusinessLayer
             return clsPaymentData.DeletePayment(PaymentID);
         }
 
-        public static DataTable GetAllPayments()
+        private static DataTable _paymentsCache;
+        private static readonly object _paymentsLock = new object();
+
+        public static DataTable GetAllPayments(bool forceRefresh = false)
         {
-            return clsPaymentData.GetAllPayments();
+            lock (_paymentsLock)
+            {
+                if (_paymentsCache == null || forceRefresh)
+                    _paymentsCache = clsPaymentData.GetAllPayments();
+                return _paymentsCache.Copy();
+            }
+        }
+
+        public static Task<DataTable> GetAllPaymentsAsync(bool forceRefresh = false)
+        {
+            return Task.Run(() => GetAllPayments(forceRefresh));
         }
 
         public static DataTable GetAllPayments(int GuestID)

--- a/Hotel_BusinessLayer/clsRoom.cs
+++ b/Hotel_BusinessLayer/clsRoom.cs
@@ -145,9 +145,22 @@ namespace Hotel_BusinessLayer
             return clsRoomData.DeleteRoom(RoomID);
         }
 
-        public static DataTable GetAllRooms()
+        private static DataTable _roomsCache;
+        private static readonly object _roomsLock = new object();
+
+        public static DataTable GetAllRooms(bool forceRefresh = false)
         {
-            return clsRoomData.GetAllRooms();
+            lock (_roomsLock)
+            {
+                if (_roomsCache == null || forceRefresh)
+                    _roomsCache = clsRoomData.GetAllRooms();
+                return _roomsCache.Copy();
+            }
+        }
+
+        public static Task<DataTable> GetAllRoomsAsync(bool forceRefresh = false)
+        {
+            return Task.Run(() => GetAllRooms(forceRefresh));
         }
 
         public static int GetRoomsCountPerRoomType(int RoomTypeID)

--- a/Hotel_BusinessLayer/clsRoomService.cs
+++ b/Hotel_BusinessLayer/clsRoomService.cs
@@ -89,9 +89,22 @@ namespace Hotel_BusinessLayer
             return false;
         }
 
-        public static DataTable GetAllRoomServices()
+        private static DataTable _roomServicesCache;
+        private static readonly object _roomServicesLock = new object();
+
+        public static DataTable GetAllRoomServices(bool forceRefresh = false)
         {
-            return clsRoomServiceData.GetAllRoomServices();
+            lock (_roomServicesLock)
+            {
+                if (_roomServicesCache == null || forceRefresh)
+                    _roomServicesCache = clsRoomServiceData.GetAllRoomServices();
+                return _roomServicesCache.Copy();
+            }
+        }
+
+        public static Task<DataTable> GetAllRoomServicesAsync(bool forceRefresh = false)
+        {
+            return Task.Run(() => GetAllRoomServices(forceRefresh));
         }
 
     }

--- a/Hotel_BusinessLayer/clsRoomType.cs
+++ b/Hotel_BusinessLayer/clsRoomType.cs
@@ -112,9 +112,22 @@ namespace Hotel_BusinessLayer
             return clsRoomTypeData.DeleteRoomType(RoomTypeID);
         }
 
-        public static DataTable GetAllRoomTypes()
+        private static DataTable _roomTypesCache;
+        private static readonly object _roomTypesLock = new object();
+
+        public static DataTable GetAllRoomTypes(bool forceRefresh = false)
         {
-            return clsRoomTypeData.GetAllRoomTypes();
+            lock (_roomTypesLock)
+            {
+                if (_roomTypesCache == null || forceRefresh)
+                    _roomTypesCache = clsRoomTypeData.GetAllRoomTypes();
+                return _roomTypesCache.Copy();
+            }
+        }
+
+        public static Task<DataTable> GetAllRoomTypesAsync(bool forceRefresh = false)
+        {
+            return Task.Run(() => GetAllRoomTypes(forceRefresh));
         }
 
         public static int GetRoomsCount(int RoomTypeID)

--- a/Hotel_BusinessLayer/clsUser.cs
+++ b/Hotel_BusinessLayer/clsUser.cs
@@ -133,9 +133,22 @@ namespace Hotel_BusinessLayer
             return clsUserData.UpdateUserPassword(UserID, hashedPassword);
         }
 
-        public static DataTable GetAllUsers()
+        private static DataTable _usersCache;
+        private static readonly object _usersLock = new object();
+
+        public static DataTable GetAllUsers(bool forceRefresh = false)
         {
-            return clsUserData.GetAllUsers();
+            lock (_usersLock)
+            {
+                if (_usersCache == null || forceRefresh)
+                    _usersCache = clsUserData.GetAllUsers();
+                return _usersCache.Copy();
+            }
+        }
+
+        public static Task<DataTable> GetAllUsersAsync(bool forceRefresh = false)
+        {
+            return Task.Run(() => GetAllUsers(forceRefresh));
         }
 
         public static int GetUsersCount()


### PR DESCRIPTION
## Summary
- add caching and async DB access for data tables
- preload additional datasets in `clsDataCache`
- refresh grids asynchronously across panels

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680d472c0883228e5868fbc5bb9cb5