### PR TITLE
Fix async call and clean csproj references

### DIFF
--- a/HotelManagementSystem/Hotel_PresentationLayer.csproj
+++ b/HotelManagementSystem/Hotel_PresentationLayer.csproj
@@ -92,9 +92,6 @@
       <HintPath>packages\System.Data.OleDb.6.0.0\lib\net461\System.Data.OleDb.dll</HintPath>
     </Reference>
     <Reference Include="System.Data.OracleClient" />
-    <Reference Include="System.Data.SqlClient, Version=4.9.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Data.SqlClient.4.9.0\lib\net461\System.Data.SqlClient.dll</HintPath>
-    </Reference>
     <Reference Include="System.Design" />
     <Reference Include="System.Diagnostics.EventLog, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Diagnostics.EventLog.6.0.0\lib\net461\System.Diagnostics.EventLog.dll</HintPath>
@@ -116,9 +113,6 @@
     </Reference>
     <Reference Include="System.IO.FileSystem.AccessControl, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.IO.FileSystem.AccessControl.5.0.0\lib\net461\System.IO.FileSystem.AccessControl.dll</HintPath>
-    </Reference>
-    <Reference Include="System.IO.Packaging, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.IO.Packaging.9.0.6\lib\net461\System.IO.Packaging.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Pipes.AccessControl, Version=4.0.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.IO.Pipes.AccessControl.5.0.0\lib\net461\System.IO.Pipes.AccessControl.dll</HintPath>
@@ -161,9 +155,6 @@
       <Private>True</Private>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Security.Cryptography.Pkcs, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>packages\System.Security.Cryptography.Pkcs.9.0.6\lib\net461\System.Security.Cryptography.Pkcs.dll</HintPath>
-    </Reference>
     <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
       <Private>True</Private>
@@ -171,9 +162,6 @@
     </Reference>
     <Reference Include="System.Security.Cryptography.ProtectedData, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>packages\System.Security.Cryptography.ProtectedData.6.0.0\lib\net461\System.Security.Cryptography.ProtectedData.dll</HintPath>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Xml, Version=9.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>packages\System.Security.Cryptography.Xml.9.0.6\lib\net461\System.Security.Cryptography.Xml.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Permissions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.Security.Permissions.6.0.0\lib\net461\System.Security.Permissions.dll</HintPath>

--- a/HotelManagementSystem/frmMain.cs
+++ b/HotelManagementSystem/frmMain.cs
@@ -135,7 +135,7 @@ namespace HotelManagementSystem
 
         private async void frmMain_Load(object sender, EventArgs e)
         {
-            _ = clsDataCache.PreloadAsync();
+            await clsDataCache.PreloadAsync();
             _EnsureForm(ref _frmDashboard);
             _EnsureForm(ref _frmReservations);
             _EnsureForm(ref _frmBookings);

--- a/HotelManagementSystem/packages.config
+++ b/HotelManagementSystem/packages.config
@@ -21,7 +21,6 @@
   <package id="System.Data.DataSetExtensions" version="4.5.0" targetFramework="net472" />
   <package id="System.Data.Odbc" version="6.0.0" targetFramework="net472" />
   <package id="System.Data.OleDb" version="6.0.0" targetFramework="net472" />
-  <package id="System.Data.SqlClient" version="4.9.0" targetFramework="net472" />
   <package id="System.Diagnostics.EventLog" version="6.0.0" targetFramework="net472" />
   <package id="System.Diagnostics.PerformanceCounter" version="6.0.0" targetFramework="net472" />
   <package id="System.DirectoryServices" version="6.0.0" targetFramework="net472" />
@@ -30,7 +29,6 @@
   <package id="System.Drawing.Common" version="6.0.0" targetFramework="net472" />
   <package id="System.IO" version="4.3.0" targetFramework="net472" />
   <package id="System.IO.FileSystem.AccessControl" version="5.0.0" targetFramework="net472" />
-  <package id="System.IO.Packaging" version="9.0.6" targetFramework="net472" />
   <package id="System.IO.Pipes.AccessControl" version="5.0.0" targetFramework="net472" />
   <package id="System.IO.Ports" version="6.0.0" targetFramework="net472" />
   <package id="System.Management" version="6.0.0" targetFramework="net472" />
@@ -47,10 +45,8 @@
   <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net472" />
   <package id="System.Security.Cryptography.Cng" version="5.0.0" targetFramework="net472" />
   <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net472" />
-  <package id="System.Security.Cryptography.Pkcs" version="9.0.6" targetFramework="net472" />
   <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net472" />
   <package id="System.Security.Cryptography.ProtectedData" version="6.0.0" targetFramework="net472" />
-  <package id="System.Security.Cryptography.Xml" version="9.0.6" targetFramework="net472" />
   <package id="System.Security.Permissions" version="6.0.0" targetFramework="net472" />
   <package id="System.Security.Principal.Windows" version="5.0.0" targetFramework="net472" />
   <package id="System.ServiceModel.Duplex" version="4.9.0" targetFramework="net472" />

--- a/Hotel_BusinessLayer/clsGuestOrder.cs
+++ b/Hotel_BusinessLayer/clsGuestOrder.cs
@@ -66,7 +66,6 @@ namespace Hotel_BusinessLayer
             int GuestID = -1;
             int RoomID = -1;
             DateTime OrderDate = DateTime.Now;
-            float Fees = -1;
             int CreatedByUserID = -1;
             int BookingID = -1;
             byte OrderType = 0;


### PR DESCRIPTION
## Summary
- remove unused `Fees` variable
- await `PreloadAsync` in main form
- drop unused package references for SqlClient and crypto packages

## Testing
- `dotnet restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680f5d97d083228c3e048a556285b7