### PR TITLE
Fix async handlers

### DIFF
--- a/HotelManagementSystem/Rooms/frmListRooms.cs
+++ b/HotelManagementSystem/Rooms/frmListRooms.cs
@@ -176,7 +176,7 @@ namespace HotelManagementSystem.Rooms
             {
                 MessageBox.Show($"Room with RoomID = {RoomID} was deleted successfully !", "Information",
                 MessageBoxButtons.OK, MessageBoxIcon.Information);
-                frmListRooms_Load(null, null);
+                await _RefreshRoomsList();
             }
 
             else
@@ -214,7 +214,7 @@ namespace HotelManagementSystem.Rooms
             
         }
 
-        private void releaseToolStripMenuItem_Click(object sender, EventArgs e)
+        private async void releaseToolStripMenuItem_Click(object sender, EventArgs e)
         {
             int RoomID = (int)dgvRoomsList.CurrentRow.Cells[0].Value;
 
@@ -230,7 +230,7 @@ namespace HotelManagementSystem.Rooms
                 {
                     MessageBox.Show($"Room with RoomID = {RoomID} was released from maintenance successfully !", "Information",
                     MessageBoxButtons.OK, MessageBoxIcon.Information);
-                    frmListRooms_Load(null, null);
+                    await _RefreshRoomsList();
                 }
 
                 else


### PR DESCRIPTION
## Summary
- fix `deleteToolStripMenuItem_Click` to await refresh
- make `releaseToolStripMenuItem_Click` async and await refresh

## Testing
- `dotnet build HotelManagementSystem/HotelManagementSystem.sln -c Release` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686811416150832288e5b9e94a650cc0