### PR TITLE
Fix ButtonState ImageSize errors

### DIFF
--- a/HotelManagementSystem/GlobalClasses/clsUtility.cs
+++ b/HotelManagementSystem/GlobalClasses/clsUtility.cs
@@ -77,22 +77,13 @@ namespace HotelManagementSystem
                     if (btn.HoverState.Image != null)
                         btn.Image = btn.HoverState.Image;
 
-                    if (!btn.HoverState.ImageSize.IsEmpty)
-                        btn.ImageSize = btn.HoverState.ImageSize;
-
                     btn.HoverState.Image = btn.Image;
-                    btn.HoverState.ImageSize = btn.ImageSize;
                 }
                 else if (ctrl is Guna2ImageButton imgBtn)
                 {
                     if (imgBtn.HoverState.Image != null)
                         imgBtn.Image = imgBtn.HoverState.Image;
-
-                    if (!imgBtn.HoverState.ImageSize.IsEmpty)
-                        imgBtn.ImageSize = imgBtn.HoverState.ImageSize;
-
                     imgBtn.HoverState.Image = imgBtn.Image;
-                    imgBtn.HoverState.ImageSize = imgBtn.ImageSize;
                 }
 
                 if (ctrl.HasChildren)


### PR DESCRIPTION
## Summary
- remove references to unavailable `ButtonState.ImageSize`

## Testing
- `mono` compiler invoked on small snippets

------
https://chatgpt.com/codex/tasks/task_e_686833a1233c83229db41678e3e1d7aa