### PR TITLE
Fix decimal validation for prices and fees

### DIFF
--- a/HotelManagementSystem/DiningMenuItems/frmAddUpdateMenuItem.cs
+++ b/HotelManagementSystem/DiningMenuItems/frmAddUpdateMenuItem.cs
@@ -179,7 +179,8 @@ namespace HotelManagementSystem.DiningMenuItems
                 return;
 
             _MenuItem.ItemName = txtItemName.Text;
-            _MenuItem.Price = Convert.ToSingle(txtPrice.Text);
+            string priceText = txtPrice.Text.Replace(',', '.');
+            _MenuItem.Price = float.Parse(priceText, System.Globalization.CultureInfo.InvariantCulture);
             _MenuItem.Description = txtDescription.Text != "" ? txtDescription.Text : "";
             _MenuItem.ItemType = (clsMenuItem.enItemTypes)(cbItemType.SelectedIndex + 1);
             _MenuItem.ImagePath = ItemImage.ImageLocation != null ? ItemImage.ImageLocation : "";

--- a/HotelManagementSystem/GlobalClasses/clsValidation.cs
+++ b/HotelManagementSystem/GlobalClasses/clsValidation.cs
@@ -29,7 +29,8 @@ namespace HotelManagementSystem
 
         public static bool ValidateFloat(string Number)
         {
-            string Pattern = @"^[0-9]*(?:\.[0-9]*)?$";
+            // Accept both dot and comma as decimal separators
+            string Pattern = @"^[0-9]*(?:[\.,][0-9]*)?$";
 
             Regex regex = new Regex(Pattern);
 

--- a/HotelManagementSystem/Rooms/RoomServices/frmAddUpdateRoomService.cs
+++ b/HotelManagementSystem/Rooms/RoomServices/frmAddUpdateRoomService.cs
@@ -82,7 +82,8 @@ namespace HotelManagementSystem.Rooms.RoomServices
 
             _RoomService.RoomServiceTitle = txtTitle.Text.Trim();
             _RoomService.RoomServiceDescription = txtDescription.Text.Trim();
-            _RoomService.RoomServiceFees =  Convert.ToSingle(txtFees.Text);
+            string feesText = txtFees.Text.Replace(',', '.');
+            _RoomService.RoomServiceFees =  float.Parse(feesText, System.Globalization.CultureInfo.InvariantCulture);
 
             if (_RoomService.Save())
             {

--- a/HotelManagementSystem/Rooms/RoomTypes/frmAddUpdateRoomType.cs
+++ b/HotelManagementSystem/Rooms/RoomTypes/frmAddUpdateRoomType.cs
@@ -87,7 +87,8 @@ namespace HotelManagementSystem.Rooms.RoomTypes
             _RoomType.RoomTypeTitle = txtRoomTypeTitle.Text;
             if(txtDescription.Text != "")
             _RoomType.RoomTypeDescription = txtDescription.Text;
-            _RoomType.RoomTypePricePerNight = Convert.ToSingle(txtPerNightPrice.Text);
+            string priceText = txtPerNightPrice.Text.Replace(',', '.');
+            _RoomType.RoomTypePricePerNight = float.Parse(priceText, System.Globalization.CultureInfo.InvariantCulture);
             _RoomType.RoomTypeCapacity = (byte)nudRoomTypeCapacity.Value;
 
             if (_RoomType.Save())


### PR DESCRIPTION
## Summary
- allow comma as decimal separator for numeric validation
- handle comma in price/fee inputs for room types, menu items, and room services

## Testing
- `dotnet build HotelManagementSystem/HotelManagementSystem.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68684467cf088322981a12fcbd23ab17