### PR TITLE
Improve count retrieval with async helper

### DIFF
--- a/HotelManagementSystem/frmDashboard.cs
+++ b/HotelManagementSystem/frmDashboard.cs
@@ -22,7 +22,7 @@ namespace HotelManagementSystem
             InitializeComponent();
         }
 
-        private void _LoadDashboardData()
+        private async Task _LoadDashboardDataAsync()
         {
             // Hide greeting and user info section
             label.Visible = false;
@@ -31,12 +31,24 @@ namespace HotelManagementSystem
             btnShowDropDownMenu.Visible = false;
             guna2GradientButton1.Visible = false;
 
-            lblRoomsCount.Text = clsRoom.GetRoomsCount().ToString();
-            lblReservationsCount.Text = clsReservation.GetReservationsCount().ToString();
-            lblBookingsCount.Text = clsBooking.GetBookingsCount().ToString();
-            lblPaymentsCount.Text = clsPayment.GetPaymentsCount().ToString();
-            lblGuestsCount.Text = (clsGuest.GetGuestsCount() + clsGuestCompanion.GetGuestCompanionsCount()).ToString();
-            lblUsersCount.Text = clsUser.GetUsersCount().ToString();
+            var roomsCountTask = clsRoom.GetRoomsCountAsync();
+            var reservationsCountTask = clsReservation.GetReservationsCountAsync();
+            var bookingsCountTask = clsBooking.GetBookingsCountAsync();
+            var paymentsCountTask = clsPayment.GetPaymentsCountAsync();
+            var guestsCountTask = clsGuest.GetGuestsCountAsync();
+            var companionsCountTask = clsGuestCompanion.GetGuestCompanionsCountAsync();
+            var usersCountTask = clsUser.GetUsersCountAsync();
+
+            await Task.WhenAll(roomsCountTask, reservationsCountTask, bookingsCountTask,
+                               paymentsCountTask, guestsCountTask, companionsCountTask,
+                               usersCountTask);
+
+            lblRoomsCount.Text = roomsCountTask.Result.ToString();
+            lblReservationsCount.Text = reservationsCountTask.Result.ToString();
+            lblBookingsCount.Text = bookingsCountTask.Result.ToString();
+            lblPaymentsCount.Text = paymentsCountTask.Result.ToString();
+            lblGuestsCount.Text = (guestsCountTask.Result + companionsCountTask.Result).ToString();
+            lblUsersCount.Text = usersCountTask.Result.ToString();
 
         }
 
@@ -59,9 +71,9 @@ namespace HotelManagementSystem
 
         }
 
-        private void frmDashboard_Load(object sender, EventArgs e)
-        {         
-            _LoadDashboardData();
+        private async void frmDashboard_Load(object sender, EventArgs e)
+        {
+            await _LoadDashboardDataAsync();
 
             _LoadChartData();
         }

--- a/Hotel_BusinessLayer/clsBooking.cs
+++ b/Hotel_BusinessLayer/clsBooking.cs
@@ -270,5 +270,10 @@ namespace Hotel_BusinessLayer
         {
             return clsBookingData.GetBookingsCount();
         }
+
+        public static Task<int> GetBookingsCountAsync()
+        {
+            return clsBookingData.GetBookingsCountAsync();
+        }
     }
 }

--- a/Hotel_BusinessLayer/clsGuest.cs
+++ b/Hotel_BusinessLayer/clsGuest.cs
@@ -155,5 +155,10 @@ namespace Hotel_BusinessLayer
             return clsGuestData.GetGuestsCount();
         }
 
+        public static Task<int> GetGuestsCountAsync()
+        {
+            return clsGuestData.GetGuestsCountAsync();
+        }
+
     }
 }

--- a/Hotel_BusinessLayer/clsGuestCompanion.cs
+++ b/Hotel_BusinessLayer/clsGuestCompanion.cs
@@ -120,5 +120,10 @@ namespace Hotel_BusinessLayer
         {
             return clsGuestCompanionData.GetGuestCompanionsCount();
         }
+
+        public static Task<int> GetGuestCompanionsCountAsync()
+        {
+            return clsGuestCompanionData.GetGuestCompanionsCountAsync();
+        }
     }
 }

--- a/Hotel_BusinessLayer/clsGuestOrder.cs
+++ b/Hotel_BusinessLayer/clsGuestOrder.cs
@@ -133,5 +133,10 @@ namespace Hotel_BusinessLayer
         {
             return clsGuestOrderData.GetGuestOrdersCount();
         }
+
+        public static Task<int> GetGuestOrdersCountAsync()
+        {
+            return clsGuestOrderData.GetGuestOrdersCountAsync();
+        }
     }
 }

--- a/Hotel_BusinessLayer/clsPayment.cs
+++ b/Hotel_BusinessLayer/clsPayment.cs
@@ -145,5 +145,10 @@ namespace Hotel_BusinessLayer
             return clsPaymentData.GetPaymentsCount();
         }
 
+        public static Task<int> GetPaymentsCountAsync()
+        {
+            return clsPaymentData.GetPaymentsCountAsync();
+        }
+
     }
 }

--- a/Hotel_BusinessLayer/clsReservation.cs
+++ b/Hotel_BusinessLayer/clsReservation.cs
@@ -266,6 +266,11 @@ namespace Hotel_BusinessLayer
             return clsReservationData.GetReservationsCount();
         }
 
+        public static Task<int> GetReservationsCountAsync()
+        {
+            return clsReservationData.GetReservationsCountAsync();
+        }
+
         public static int GetAvailableRoomType()
         {
             return clsReservationData.GetAvailableRoomType();

--- a/Hotel_BusinessLayer/clsRoom.cs
+++ b/Hotel_BusinessLayer/clsRoom.cs
@@ -178,14 +178,29 @@ namespace Hotel_BusinessLayer
             return clsRoomData.GetRoomsCountPerRoomType(RoomTypeID);
         }
 
+        public static Task<int> GetRoomsCountPerRoomTypeAsync(int RoomTypeID)
+        {
+            return clsRoomData.GetRoomsCountPerRoomTypeAsync(RoomTypeID);
+        }
+
         public static int GetRoomsCount()
         {
             return clsRoomData.GetRoomsCount();
         }
 
+        public static Task<int> GetRoomsCountAsync()
+        {
+            return clsRoomData.GetRoomsCountAsync();
+        }
+
         public static int GetRoomsCountPerStatus(enAvailabilityStatus AvailabilityStatus)
         {
             return clsRoomData.GetRoomsCountPerStatus((byte)AvailabilityStatus);
+        }
+
+        public static Task<int> GetRoomsCountPerStatusAsync(enAvailabilityStatus AvailabilityStatus)
+        {
+            return clsRoomData.GetRoomsCountPerStatusAsync((byte)AvailabilityStatus);
         }
 
         public static string GetAvailabilityStatus(enAvailabilityStatus AvailabilityStatus)

--- a/Hotel_BusinessLayer/clsUser.cs
+++ b/Hotel_BusinessLayer/clsUser.cs
@@ -171,5 +171,10 @@ namespace Hotel_BusinessLayer
             return clsUserData.GetUsersCount();
         }
 
+        public static Task<int> GetUsersCountAsync()
+        {
+            return clsUserData.GetUsersCountAsync();
+        }
+
     }
 }

--- a/Hotel_DataAccessLayer/Hotel_DataAccessLayer.csproj
+++ b/Hotel_DataAccessLayer/Hotel_DataAccessLayer.csproj
@@ -41,26 +41,27 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="clsBookingData.cs" />
-    <Compile Include="clsCountryData.cs" />
-    <Compile Include="clsDataAccessSettings.cs" />
-    <Compile Include="clsGuestCompanionData.cs" />
-    <Compile Include="clsGuestData.cs" />
-    <Compile Include="clsGuestOrderData.cs" />
-    <Compile Include="clsMenuItemData.cs" />
-    <Compile Include="clsOrderItemData.cs" />
-    <Compile Include="clsPaymentData.cs" />
-    <Compile Include="clsPersonData.cs" />
-    <Compile Include="clsReservationData.cs" />
-    <Compile Include="clsRoomData.cs" />
-    <Compile Include="clsRoomServiceData.cs" />
-    <Compile Include="clsRoomTypeData.cs" />
-    <Compile Include="clsUserData.cs" />
-    <Compile Include="ErrorLogs\clsGlobal.cs" />
-    <Compile Include="ErrorLogs\clsLogger.cs" />
-    <Compile Include="ErrorLogs\clsDBLogger.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
+    <ItemGroup>
+        <Compile Include="clsBookingData.cs" />
+        <Compile Include="clsCountryData.cs" />
+        <Compile Include="clsDataAccessSettings.cs" />
+        <Compile Include="clsGuestCompanionData.cs" />
+        <Compile Include="clsGuestData.cs" />
+        <Compile Include="clsGuestOrderData.cs" />
+        <Compile Include="clsMenuItemData.cs" />
+        <Compile Include="clsOrderItemData.cs" />
+        <Compile Include="clsPaymentData.cs" />
+        <Compile Include="clsPersonData.cs" />
+        <Compile Include="clsReservationData.cs" />
+        <Compile Include="clsRoomData.cs" />
+        <Compile Include="clsRoomServiceData.cs" />
+        <Compile Include="clsRoomTypeData.cs" />
+        <Compile Include="clsUserData.cs" />
+        <Compile Include="clsSqlHelper.cs" />
+        <Compile Include="ErrorLogs\clsGlobal.cs" />
+        <Compile Include="ErrorLogs\clsLogger.cs" />
+        <Compile Include="ErrorLogs\clsDBLogger.cs" />
+        <Compile Include="Properties\AssemblyInfo.cs" />
+    </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Hotel_DataAccessLayer/clsBookingData.cs
+++ b/Hotel_DataAccessLayer/clsBookingData.cs
@@ -644,36 +644,14 @@ namespace Hotel_DataAccessLayer
 
         public static int GetBookingsCount()
         {
-            int BookingsCount = 0;
+            const string query = @"SELECT COUNT(BookingID) FROM Bookings;";
+            return clsSqlHelper.ExecuteScalarInt(query);
+        }
 
-            SqlConnection connection = new SqlConnection(clsDataAccessSettings.connectionString);
-
-            string query = @"SELECT COUNT(BookingID)
-                            FROM Bookings;";
-
-            SqlCommand command = new SqlCommand(query, connection);
-
-            object reader = null;
-
-            try
-            {
-                connection.Open();
-                reader = command.ExecuteScalar();
-
-                BookingsCount = (int)reader;
-            }
-
-            catch (Exception ex)
-            {
-                clsGlobal.DBLogger.LogError(ex.Message, ex.GetType().FullName);
-            }
-
-            finally
-            {
-                connection.Close();
-            }
-
-            return BookingsCount;
+        public static Task<int> GetBookingsCountAsync()
+        {
+            const string query = @"SELECT COUNT(BookingID) FROM Bookings;";
+            return clsSqlHelper.ExecuteScalarIntAsync(query);
         }
 
     }

--- a/Hotel_DataAccessLayer/clsGuestCompanionData.cs
+++ b/Hotel_DataAccessLayer/clsGuestCompanionData.cs
@@ -351,36 +351,14 @@ namespace Hotel_DataAccessLayer
 
         public static int GetGuestCompanionsCount()
         {
-            int GuestCompanionsCount = 0;
+            const string query = @"SELECT COUNT(GuestCompanionID) FROM GuestCompanions;";
+            return clsSqlHelper.ExecuteScalarInt(query);
+        }
 
-            SqlConnection connection = new SqlConnection(clsDataAccessSettings.connectionString);
-
-            string query = @"SELECT COUNT(GuestCompanionID)
-                            FROM GuestCompanions;";
-
-            SqlCommand command = new SqlCommand(query, connection);
-
-            object reader = null;
-
-            try
-            {
-                connection.Open();
-                reader = command.ExecuteScalar();
-
-                GuestCompanionsCount = (int)reader;
-            }
-
-            catch (Exception ex)
-            {
-                clsGlobal.DBLogger.LogError(ex.Message, ex.GetType().FullName);
-            }
-
-            finally
-            {
-                connection.Close();
-            }
-
-            return GuestCompanionsCount;
+        public static Task<int> GetGuestCompanionsCountAsync()
+        {
+            const string query = @"SELECT COUNT(GuestCompanionID) FROM GuestCompanions;";
+            return clsSqlHelper.ExecuteScalarIntAsync(query);
         }
 
 

--- a/Hotel_DataAccessLayer/clsGuestData.cs
+++ b/Hotel_DataAccessLayer/clsGuestData.cs
@@ -460,36 +460,14 @@ namespace Hotel_DataAccessLayer
 
         public static int GetGuestsCount()
         {
-            int GuestsCount = 0;
+            const string query = @"SELECT COUNT(GuestID) FROM Guests;";
+            return clsSqlHelper.ExecuteScalarInt(query);
+        }
 
-            SqlConnection connection = new SqlConnection(clsDataAccessSettings.connectionString);
-
-            string query = @"SELECT COUNT(GuestID)
-                            FROM Guests;";
-
-            SqlCommand command = new SqlCommand(query, connection);
-
-            object reader = null;
-
-            try
-            {
-                connection.Open();
-                reader = command.ExecuteScalar();
-
-                GuestsCount = (int)reader;
-            }
-
-            catch (Exception ex)
-            {
-                clsGlobal.DBLogger.LogError(ex.Message, ex.GetType().FullName);
-            }
-
-            finally
-            {
-                connection.Close();
-            }
-
-            return GuestsCount;
+        public static Task<int> GetGuestsCountAsync()
+        {
+            const string query = @"SELECT COUNT(GuestID) FROM Guests;";
+            return clsSqlHelper.ExecuteScalarIntAsync(query);
         }
 
 

--- a/Hotel_DataAccessLayer/clsGuestOrderData.cs
+++ b/Hotel_DataAccessLayer/clsGuestOrderData.cs
@@ -344,37 +344,14 @@ namespace Hotel_DataAccessLayer
 
         public static int GetGuestOrdersCount()
         {
-            int OrdersCount = 0;
+            const string query = @"SELECT COUNT(GuestOrderID) FROM GuestOrders;";
+            return clsSqlHelper.ExecuteScalarInt(query);
+        }
 
-            SqlConnection connection = new SqlConnection(clsDataAccessSettings.connectionString);
-
-            string query = @"SELECT COUNT(GuestOrderID) FROM GuestOrders;";
-
-            SqlCommand command = new SqlCommand(query, connection);
-
-            object RowsCount = null;
-
-            try
-            {
-                connection.Open();
-                RowsCount = command.ExecuteScalar();
-
-                if (RowsCount != null && int.TryParse(RowsCount.ToString(), out int Count))
-                {
-                    OrdersCount = Count;
-                }
-                else
-                    OrdersCount = 0;
-            }
-            catch (Exception ex)
-            {
-                clsGlobal.DBLogger.LogError(ex.Message, ex.GetType().FullName);
-            }
-            finally
-            {
-                connection.Close();
-            }
-            return OrdersCount;
+        public static Task<int> GetGuestOrdersCountAsync()
+        {
+            const string query = @"SELECT COUNT(GuestOrderID) FROM GuestOrders;";
+            return clsSqlHelper.ExecuteScalarIntAsync(query);
         }
 
         public static float GetOrderPaidFees(int GuestOrderID)

--- a/Hotel_DataAccessLayer/clsPaymentData.cs
+++ b/Hotel_DataAccessLayer/clsPaymentData.cs
@@ -395,36 +395,14 @@ namespace Hotel_DataAccessLayer
 
         public static int GetPaymentsCount()
         {
-            int PaymentsCount = 0;
+            const string query = @"SELECT COUNT(PaymentID) FROM Payments;";
+            return clsSqlHelper.ExecuteScalarInt(query);
+        }
 
-            SqlConnection connection = new SqlConnection(clsDataAccessSettings.connectionString);
-
-            string query = @"SELECT COUNT(PaymentID)
-                            FROM Payments;";
-
-            SqlCommand command = new SqlCommand(query, connection);
-
-            object reader = null;
-
-            try
-            {
-                connection.Open();
-                reader = command.ExecuteScalar();
-
-                PaymentsCount = (int)reader;
-            }
-
-            catch (Exception ex)
-            {
-                clsGlobal.DBLogger.LogError(ex.Message, ex.GetType().FullName);
-            }
-
-            finally
-            {
-                connection.Close();
-            }
-
-            return PaymentsCount;
+        public static Task<int> GetPaymentsCountAsync()
+        {
+            const string query = @"SELECT COUNT(PaymentID) FROM Payments;";
+            return clsSqlHelper.ExecuteScalarIntAsync(query);
         }
 
     }

--- a/Hotel_DataAccessLayer/clsReservationData.cs
+++ b/Hotel_DataAccessLayer/clsReservationData.cs
@@ -425,36 +425,14 @@ namespace Hotel_DataAccessLayer
 
         public static int GetReservationsCount()
         {
-            int ReservationsCount = 0;
+            const string query = @"SELECT COUNT(ReservationID) FROM Reservations;";
+            return clsSqlHelper.ExecuteScalarInt(query);
+        }
 
-            SqlConnection connection = new SqlConnection(clsDataAccessSettings.connectionString);
-
-            string query = @"SELECT COUNT(ReservationID)
-                            FROM Reservations;";
-
-            SqlCommand command = new SqlCommand(query, connection);
-
-            object reader = null;
-
-            try
-            {
-                connection.Open();
-                reader = command.ExecuteScalar();
-
-                ReservationsCount = (int)reader;
-            }
-
-            catch (Exception ex)
-            {
-                clsGlobal.DBLogger.LogError(ex.Message, ex.GetType().FullName);
-            }
-
-            finally
-            {
-                connection.Close();
-            }
-
-            return ReservationsCount;
+        public static Task<int> GetReservationsCountAsync()
+        {
+            const string query = @"SELECT COUNT(ReservationID) FROM Reservations;";
+            return clsSqlHelper.ExecuteScalarIntAsync(query);
         }
 
         public static int GetAvailableRoomType()

--- a/Hotel_DataAccessLayer/clsRoomData.cs
+++ b/Hotel_DataAccessLayer/clsRoomData.cs
@@ -405,112 +405,42 @@ namespace Hotel_DataAccessLayer
 
         public static int GetRoomsCountPerRoomType(int RoomTypeID)
         {
-            int RoomsCount = 0;
+            const string query = @"SELECT COUNT(*) FROM Rooms WHERE RoomTypeID = @RoomTypeID";
+            SqlParameter param = new SqlParameter("@RoomTypeID", RoomTypeID);
+            return clsSqlHelper.ExecuteScalarInt(query, param);
+        }
 
-            SqlConnection connection = new SqlConnection(clsDataAccessSettings.connectionString);
-
-            string query = @"SELECT Count(*) FROM Rooms WHERE RoomTypeID = @RoomTypeID";
-
-            SqlCommand command = new SqlCommand(query, connection);
-
-            command.Parameters.AddWithValue("@RoomTypeID", RoomTypeID);
-
-            object RowsCount = null;
-
-            try
-            {
-                connection.Open();
-                RowsCount = command.ExecuteScalar();
-
-                if (RowsCount != null && int.TryParse(RowsCount.ToString(), out int Count))
-                {
-                    RoomsCount = Count;
-                }
-                else
-                    RoomsCount = 0;
-            }
-            catch (Exception ex)
-            {
-                clsGlobal.DBLogger.LogError(ex.Message, ex.GetType().FullName);
-            }
-            finally
-            {
-                connection.Close();
-            }
-            return RoomsCount;
+        public static Task<int> GetRoomsCountPerRoomTypeAsync(int RoomTypeID)
+        {
+            const string query = @"SELECT COUNT(*) FROM Rooms WHERE RoomTypeID = @RoomTypeID";
+            SqlParameter param = new SqlParameter("@RoomTypeID", RoomTypeID);
+            return clsSqlHelper.ExecuteScalarIntAsync(query, param);
         }
 
         public static int GetRoomsCount()
         {
-            int RoomsCount = 0;
+            const string query = @"SELECT COUNT(RoomID) FROM Rooms;";
+            return clsSqlHelper.ExecuteScalarInt(query);
+        }
 
-            SqlConnection connection = new SqlConnection(clsDataAccessSettings.connectionString);
-
-            string query = @"SELECT COUNT(RoomID) FROM Rooms;";
-
-            SqlCommand command = new SqlCommand(query, connection);
-
-            object RowsCount = null;
-
-            try
-            {
-                connection.Open();
-                RowsCount = command.ExecuteScalar();
-
-                if (RowsCount != null && int.TryParse(RowsCount.ToString(), out int Count))
-                {
-                    RoomsCount = Count;
-                }
-                else
-                    RoomsCount = 0;
-            }
-            catch (Exception ex)
-            {
-                clsGlobal.DBLogger.LogError(ex.Message, ex.GetType().FullName);
-            }
-            finally
-            {
-                connection.Close();
-            }
-            return RoomsCount;
+        public static Task<int> GetRoomsCountAsync()
+        {
+            const string query = @"SELECT COUNT(RoomID) FROM Rooms;";
+            return clsSqlHelper.ExecuteScalarIntAsync(query);
         }
 
         public static int GetRoomsCountPerStatus(byte AvailabilityStatus)
         {
-            int RoomsCount = 0;
+            const string query = @"SELECT COUNT(RoomID) FROM Rooms WHERE AvailabilityStatus = @AvailabilityStatus;";
+            SqlParameter param = new SqlParameter("@AvailabilityStatus", AvailabilityStatus);
+            return clsSqlHelper.ExecuteScalarInt(query, param);
+        }
 
-            SqlConnection connection = new SqlConnection(clsDataAccessSettings.connectionString);
-
-            string query = @"SELECT COUNT(RoomID) FROM Rooms
-                            WHERE AvailabilityStatus = @AvailabilityStatus;";
-
-            SqlCommand command = new SqlCommand(query, connection);
-
-            command.Parameters.AddWithValue("@AvailabilityStatus", AvailabilityStatus);
-
-            object RowsCount = null;
-
-            try
-            {
-                connection.Open();
-                RowsCount = command.ExecuteScalar();
-
-                if (RowsCount != null && int.TryParse(RowsCount.ToString(), out int Count))
-                {
-                    RoomsCount = Count;
-                }
-                else
-                    RoomsCount = 0;
-            }
-            catch (Exception ex)
-            {
-                clsGlobal.DBLogger.LogError(ex.Message, ex.GetType().FullName);
-            }
-            finally
-            {
-                connection.Close();
-            }
-            return RoomsCount;
+        public static Task<int> GetRoomsCountPerStatusAsync(byte AvailabilityStatus)
+        {
+            const string query = @"SELECT COUNT(RoomID) FROM Rooms WHERE AvailabilityStatus = @AvailabilityStatus;";
+            SqlParameter param = new SqlParameter("@AvailabilityStatus", AvailabilityStatus);
+            return clsSqlHelper.ExecuteScalarIntAsync(query, param);
         }
 
         public static DataTable GetRoomsPerRoomType(int RoomTypeID, byte AvailabilityStatus)

--- a/Hotel_DataAccessLayer/clsSqlHelper.cs
+++ b/Hotel_DataAccessLayer/clsSqlHelper.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Data.SqlClient;
+using System.Threading.Tasks;
+using Hotel_DataAccessLayer.ErrorLogs;
+
+namespace Hotel_DataAccessLayer
+{
+    internal static class clsSqlHelper
+    {
+        public static int ExecuteScalarInt(string query, params SqlParameter[] parameters)
+        {
+            using (SqlConnection connection = clsDataAccessSettings.CreateConnection())
+            using (SqlCommand command = new SqlCommand(query, connection))
+            {
+                if (parameters != null && parameters.Length > 0)
+                    command.Parameters.AddRange(parameters);
+
+                try
+                {
+                    connection.Open();
+                    object result = command.ExecuteScalar();
+                    return (result != null && int.TryParse(result.ToString(), out int count)) ? count : 0;
+                }
+                catch (Exception ex)
+                {
+                    clsGlobal.DBLogger.LogError(ex.Message, ex.GetType().FullName);
+                    return 0;
+                }
+            }
+        }
+
+        public static async Task<int> ExecuteScalarIntAsync(string query, params SqlParameter[] parameters)
+        {
+            using (SqlConnection connection = clsDataAccessSettings.CreateConnection())
+            using (SqlCommand command = new SqlCommand(query, connection))
+            {
+                if (parameters != null && parameters.Length > 0)
+                    command.Parameters.AddRange(parameters);
+
+                try
+                {
+                    await connection.OpenAsync();
+                    object result = await command.ExecuteScalarAsync();
+                    return (result != null && int.TryParse(result.ToString(), out int count)) ? count : 0;
+                }
+                catch (Exception ex)
+                {
+                    clsGlobal.DBLogger.LogError(ex.Message, ex.GetType().FullName);
+                    return 0;
+                }
+            }
+        }
+    }
+}

--- a/Hotel_DataAccessLayer/clsUserData.cs
+++ b/Hotel_DataAccessLayer/clsUserData.cs
@@ -413,36 +413,14 @@ namespace Hotel_DataAccessLayer
 
         public static int GetUsersCount()
         {
-            int UsersCount = 0;
+            const string query = @"SELECT COUNT(UserID) FROM Users;";
+            return clsSqlHelper.ExecuteScalarInt(query);
+        }
 
-            SqlConnection connection = clsDataAccessSettings.CreateConnection();
-
-            string query = @"SELECT COUNT(UserID)
-                            FROM Users;";
-
-            SqlCommand command = new SqlCommand(query, connection);
-
-            object reader = null;
-
-            try
-            {
-                connection.Open();
-                reader = command.ExecuteScalar();
-
-                UsersCount = (int)reader;
-            }
-
-            catch (Exception ex)
-            {
-                clsGlobal.DBLogger.LogError(ex.Message, ex.GetType().FullName);
-            }
-
-            finally
-            {
-                connection.Close();
-            }
-
-            return UsersCount;
+        public static Task<int> GetUsersCountAsync()
+        {
+            const string query = @"SELECT COUNT(UserID) FROM Users;";
+            return clsSqlHelper.ExecuteScalarIntAsync(query);
         }
 
 


### PR DESCRIPTION
## Summary
- centralize scalar operations in `clsSqlHelper`
- refactor `Get*Count` methods to use the helper and expose async variants
- add async wrappers in business layer
- load dashboard data asynchronously for faster UI start

## Testing
- `dotnet build HotelManagementSystem/HotelManagementSystem.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f1a68670832281594844fddff077