### PR TITLE
Fix missing async using and unused catch variable

### DIFF
--- a/Hotel_BusinessLayer/clsPerson.cs
+++ b/Hotel_BusinessLayer/clsPerson.cs
@@ -1,6 +1,7 @@
 ﻿using Hotel_DataAccessLayer;
 using System;
 using System.Data;
+using System.Threading.Tasks;
 
 namespace Hotel_BusinessLayer
 {

--- a/Hotel_DataAccessLayer/clsPersonData.cs
+++ b/Hotel_DataAccessLayer/clsPersonData.cs
@@ -438,6 +438,7 @@ namespace Hotel_DataAccessLayer
             }
             catch (Exception ex)
             {
+                clsGlobal.DBLogger.LogError(ex.Message, ex.GetType().FullName);
                 return false;
             }
             finally


### PR DESCRIPTION
## Summary
- add missing `System.Threading.Tasks` using in `clsPerson`
- log caught exception in `clsPersonData.DeletePerson` to avoid unused variable warning

## Testing
- ❌ `dotnet --version` *(fails: command not found)*
- ❌ `nuget help` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f87a12908322b8a0e5d40b54e629